### PR TITLE
remove getDOMNode() for react 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ React Packery Mixin
 #### Introduction:
 A mixin for React.js to use Metafizzy Packery
 
+#### Which version should I use?
+React Packery Mixin 0.2.x is compatible with React 0.14 and above only. For older versions of React, use a 0.1.x version of React Packery Mixin.
+
 #### Usage:
 
 * The mixin is bundled with packery, so no additional dependencies needed!

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,13 +11,13 @@ function PackeryMixin() {
 
             initializePackery: function(force) {
                 if (!this.packery || force) {
-                    this.packery = new Packery(this.refs[reference].getDOMNode(), options);
+                    this.packery = new Packery(this.refs[reference], options);
                     this.domChildren = this.getNewDomChildren();
                 }
             },
 
             getNewDomChildren: function () {
-                var node = this.refs[reference].getDOMNode();
+                var node = this.refs[reference];
                 var children = options.itemSelector ? node.querySelectorAll(options.itemSelector) : node.children;
 
                 return Array.prototype.slice.call(children);
@@ -74,7 +74,7 @@ function PackeryMixin() {
             },
 
             imagesLoaded: function() {
-                imagesloaded(this.refs[reference].getDOMNode(), function(instance) {
+                imagesloaded(this.refs[reference], function(instance) {
                     this.packery.layout();
                 }.bind(this));
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-packery-mixin",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "main": "./lib/index",
   "description": "A packery mixin for React.js",
   "dependencies": {


### PR DESCRIPTION
Fixes #5 for me, I guess you will need to move 0.1.9 to another branch though.
